### PR TITLE
Put back local dev toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### backend
 - Import Postgre database from this dump: https://github.com/sei-international/TRASE/tree/master/DB
-- Checkout [this branch](https://github.com/nerik/TRASE/tree/API-fixes) and run the API server:
+- Clone [the backend](https://github.com/sei-international/TRASE) and run the API server:
 ```
 python API/server.py
 ```
@@ -17,7 +17,7 @@ npm i
 ```
 - and run:
 ```
-npm start
+npm run dev
 ```
 - [http://localhost:9090/](http://localhost:9090/prev)
 

--- a/index.html
+++ b/index.html
@@ -10,8 +10,10 @@
 <body>
   <svg style="width:6200px;height:2000px"></svg>
 <script>
-  document.write('<script src="http://' + (location.host || 'localhost').split(':')[0] +
-  ':35729/livereload.js?snipver=1"></' + 'script>')
+  if (window.location.href.match('localhost')) {
+    document.write('<script src="http://' + (location.host || 'localhost').split(':')[0] +
+    ':35729/livereload.js?snipver=1"></' + 'script>')
+  }
 </script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/4.2.1/d3.min.js"></script>
 <script src="https://cdn.jsdelivr.net/lodash/4.14.2/lodash.min.js"></script>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "",
   "main": "server.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "serve": "http-server -s -p 9090 .",
+    "livereload": "livereload . -d",
+    "dev": "npm run livereload & npm run serve"
   },
   "repository": {
     "type": "git",
@@ -17,7 +20,9 @@
   },
   "homepage": "https://github.com/Vizzuality/TRASE-frontend#readme",
   "devDependencies": {
-    "eslint": "^3.1.1"
+    "eslint": "^3.1.1",
+    "http-server": "^0.9.0",
+    "livereload": "^0.5.0"
   },
   "dependencies": {
     "basic-auth-connect": "^1.0.0",


### PR DESCRIPTION
I need this basic tooling to continue on the proto.
This shouldn't affect Heroku deployment, dev server lauch has been moved to a separate npm task.
