### PR TITLE
fix for authenticated ajax call

### DIFF
--- a/config/application.js
+++ b/config/application.js
@@ -19,7 +19,8 @@ app.use(bodyParser.urlencoded({extended: false}));
 // parse application/json
 app.use(bodyParser.json());
 // Serving assets from public folder
-app.use(auth, express.static(path.join(rootPath, 'dist')));
+app.use(auth);
+app.use(express.static(path.join(rootPath, 'dist')));
 app.use(express.static(path.join(rootPath, 'public')));
 
 module.exports = app;

--- a/config/auth.js
+++ b/config/auth.js
@@ -8,6 +8,10 @@ var auth = function (req, res, next) {
     return res.sendStatus(401);
   }
 
+  if (req.url === '/sample.json') {
+    return next();
+  }
+
   var user = basicAuth(req);
 
   if (!user || !user.name || !user.pass) {


### PR DESCRIPTION
Currently the deployed version is broken because it cannot load the test JSON file (used while the backend is not yet available)
For some reason the auth middleware doesn't get user credentials for the sample.json file (and by extent all files served through ajax I guess)
This is a crappy fix, @tiagojsag do you have a better idea? 
