### PR TITLE
fixed links rendering bug

### DIFF
--- a/html/flows.ejs
+++ b/html/flows.ejs
@@ -368,6 +368,7 @@
         <svg class="js-sankey-canvas sankey">
           <g class="sankey-container">
             <rect class="sankey-bg"></rect>
+            <g class="sankey-links"></g>
             <g class="sankey-columns">
               <g class="sankey-column">
                 <g class="sankey-nodes"></g>
@@ -382,7 +383,6 @@
                 <g class="sankey-nodes"></g>
               </g>
             </g>
-            <g class="sankey-links"></g>
           </g>
         </svg>
       </div>

--- a/styles/components/sankey.scss
+++ b/styles/components/sankey.scss
@@ -11,7 +11,7 @@
     cursor: pointer;
 
     .sankey-node-rect {
-      fill: rgba($white, .5);
+      fill: $white-two;
       stroke: $pinkish-grey-two;
       stroke-width: 1px;
     }


### PR DESCRIPTION
this fixes the links rendering bug by simply putting the filled nodes
on top of the links.
To properly fix this, we´d need to address the fact that sometimes the
link is thicker than the available width between 2 columns. One way
would be to have a separate rendering mode for thick links + high ys
delta, drawing a filled path thinner in the middle, instead of a simple
stroke.
