### PR TITLE
fixed typo in landing text

### DIFF
--- a/html/index.ejs
+++ b/html/index.ejs
@@ -59,7 +59,7 @@
         <div class="c-map-risks">
           <div class="map-container">
             <h3 class="title -big -center -light">What are the sustainability risks associated with
-              the trade <br/>of
+              the trade <br/>in
               <div class="c-dropdown -homepage -big" data-dropdown="commodity">
                 <span class="js-dropdown-title dropdown-title">
                   -
@@ -74,7 +74,7 @@
                   <li class="js-dropdown-item dropdown-item" data-value="Beef">Beef</li>
                 </ul>
               </div>
-              in
+              from
               <div class="c-dropdown -homepage -big" data-dropdown="country">
                 <span class="js-dropdown-title dropdown-title">
                   -


### PR DESCRIPTION
Mentioned here: https://basecamp.com/1756858/projects/12498794/messages/64228600

`1) Question above map on landing page is bad English (our mistake) and should read "What are the sustainability risks associated with the trade in Soy from Brazil?"`

`2) Please can you implement the click through to tool on "find out here"`. This one should be already implemented.