### PR TITLE
faster GET_NODES

### DIFF
--- a/scripts/reducers/helpers/getVisibleNodes.js
+++ b/scripts/reducers/helpers/getVisibleNodes.js
@@ -1,5 +1,3 @@
-import niceNumber from 'utils/niceNumber';
-
 export default function(links, nodesDict, nodesMeta, columnIndexes) {
   const nodeIdsList = [];
   const nodes = [];
@@ -31,7 +29,6 @@ export default function(links, nodesDict, nodesMeta, columnIndexes) {
 // TODO get data from get_nodes instead of flow meta (except for heights)
 // see setNodesMeta.js
 const _setNodesMeta = (nodesDict, nodesMeta) => {
-
   const nodesDictWithMeta = {};
 
   nodesMeta.nodeHeights.forEach(nodeHeight => {
@@ -46,7 +43,7 @@ const _setNodesMeta = (nodesDict, nodesMeta) => {
       node.quant = Math.round(node.quant);
     }
 
-    node.quantNice = niceNumber(node.quant);
+    node.quantNice = node.quant.toFixed(1);
 
     nodesDictWithMeta[nodeId] = node;
   });

--- a/scripts/reducers/helpers/setNodesMeta.js
+++ b/scripts/reducers/helpers/setNodesMeta.js
@@ -1,35 +1,26 @@
 import _ from 'lodash';
-import niceNumber from 'utils/niceNumber';
 import getNodeMetaUid from './getNodeMetaUid';
 
 export default function(nodesDict, nodesMeta, layers) {
+
   const layersByUID =_.keyBy(layers, 'uid');
   const nodesDictWithMeta = {};
-  const nodeIds = Object.keys(nodesDict).map(id => parseInt(id, 10));
 
-  nodeIds.forEach(nodeId => {
-    const node = nodesDict[nodeId];
-    const nodeWithMeta = _.cloneDeep(node);
-
-    const nodeMeta = nodesMeta.find(nodeMeta => nodeMeta.id === nodeId);
-    nodeWithMeta.meta = {};
-
-    if (nodeMeta) {
-      nodeMeta.values.forEach(layerValue => {
-        if (!nodeWithMeta.meta) nodeWithMeta.meta = {};
-        const uid = getNodeMetaUid(layerValue.type, layerValue.id);
-        nodeWithMeta.meta[uid] = {
-          rawValue: layerValue.rawValue,
-          rawValueNice: niceNumber(layerValue.rawValue),
-          value3: layerValue.value3,
-          value5: layerValue.value5,
-          name: layersByUID[uid].name,
-          unit: layersByUID[uid].unit,
-        };
-      });
-    }
-
-    nodesDictWithMeta[nodeId] = nodeWithMeta;
+  nodesMeta.forEach(nodeMeta => {
+    const nodeId = parseInt(nodeMeta.id);
+    const nodeWithMeta = _.cloneDeep(nodesDict[nodeId]);
+    nodeMeta.values.forEach(layerValue => {
+      if (!nodeWithMeta.meta) nodeWithMeta.meta = {};
+      const uid = getNodeMetaUid(layerValue.type, layerValue.id);
+      nodeWithMeta.meta[uid] = {
+        rawValue: layerValue.rawValue,
+        rawValueNice: layerValue.rawValue.toFixed(1),
+        value3: layerValue.value3,
+        value5: layerValue.value5,
+        name: layersByUID[uid].name,
+        unit: layersByUID[uid].unit,
+      };
+    });
   });
 
   return nodesDictWithMeta;

--- a/scripts/utils/niceNumber.js
+++ b/scripts/utils/niceNumber.js
@@ -1,4 +1,0 @@
-export default n => n.toLocaleString(undefined, {
-  minimumFractionDigits: 1,
-  maximumFractionDigits: 1
-});


### PR DESCRIPTION
This is a first step towards avoiding Jorge getting crazy with the initial page load time.
(it's a ~5s gain on my machine)

- refactored setNodesMeta
- removed `niceNumber`. Turns out `Number.toLocaleString` is crazy slow on 1000s of elements. In the future it might be interesting to see if numbers shouldn't already come formatted from the API