### PR TITLE
faster setGeoJSONMeta

### DIFF
--- a/scripts/actions/flows.actions.js
+++ b/scripts/actions/flows.actions.js
@@ -251,7 +251,7 @@ export function loadMapVectorLayers() {
         const topoJSON = JSON.parse(layerPayload);
         const key = Object.keys(topoJSON.objects)[0];
         const geoJSON = topojson.feature(topoJSON, topoJSON.objects[key]);
-        setGeoJSONMeta(geoJSON, getState().flows.nodesDict, geoColumn.id);
+        setGeoJSONMeta(geoJSON, getState().flows.nodesDict, getState().flows.geoIdsDict, geoColumn.id);
         geoData[geoColumn.name] = geoJSON;
       });
 

--- a/scripts/actions/helpers/setGeoJSONMeta.js
+++ b/scripts/actions/helpers/setGeoJSONMeta.js
@@ -1,9 +1,7 @@
-import getNodeIdFromGeoId from 'actions/helpers/getNodeIdFromGeoId';
-
-export default (geoJSON, nodesDict, columnId) => {
+export default (geoJSON, nodesDict, geoIdsDict, columnId) => {
   geoJSON.features.forEach(feature => {
     const geoId = feature.properties.geoid;
-    const nodeId = getNodeIdFromGeoId(geoId, nodesDict, columnId);
+    const nodeId = geoIdsDict[`${columnId}-${geoId}`];
     const node = nodesDict[nodeId];
     if (node) {
       feature.properties.hasFlows = node.hasFlows;

--- a/scripts/reducers/flows.reducer.js
+++ b/scripts/reducers/flows.reducer.js
@@ -45,8 +45,8 @@ export default function (state = {}, action) {
   case actions.GET_COLUMNS: {
     const rawNodes = JSON.parse(action.payload[0]).data;
     const columns = JSON.parse(action.payload[1]).data;
-    const nodesDict = getNodesDict(rawNodes, columns);
-    newState = Object.assign({}, state, { columns, nodesDict, initialDataLoading: false });
+    const { nodesDict, geoIdsDict } = getNodesDict(rawNodes, columns);
+    newState = Object.assign({}, state, { columns, nodesDict, geoIdsDict, initialDataLoading: false });
     break;
   }
 

--- a/scripts/reducers/helpers/getNodesDict.js
+++ b/scripts/reducers/helpers/getNodesDict.js
@@ -1,9 +1,9 @@
 import getFactSheetLink from 'utils/getFactSheetLink';
 
 export default function (rawNodes, columns /*, nodesMeta*/) {
-
   // store in node dict for use in getVisibleNodes
   const nodesDict = {};
+  const geoIdsDict = {};
   rawNodes.forEach(node => {
     const columnId = node.columnId;
     const column = columns.find(column => column.id === columnId);
@@ -32,7 +32,7 @@ export default function (rawNodes, columns /*, nodesMeta*/) {
     newNode.link = getFactSheetLink(newNode.id, newNode.columnId);
 
     nodesDict[parseInt(node.id)] = newNode;
+    geoIdsDict[`${columnId}-${node.geoId}`] = node.id;
   });
-
-  return nodesDict;
+  return { nodesDict, geoIdsDict};
 }

--- a/scripts/reducers/helpers/setNodesMeta.js
+++ b/scripts/reducers/helpers/setNodesMeta.js
@@ -2,7 +2,6 @@ import _ from 'lodash';
 import getNodeMetaUid from './getNodeMetaUid';
 
 export default function(nodesDict, nodesMeta, layers) {
-
   const layersByUID =_.keyBy(layers, 'uid');
   const nodesDictWithMeta = {};
 
@@ -21,7 +20,7 @@ export default function(nodesDict, nodesMeta, layers) {
         unit: layersByUID[uid].unit,
       };
     });
+    nodesDictWithMeta[nodeId] = nodeWithMeta;
   });
-
   return nodesDictWithMeta;
 }


### PR DESCRIPTION
Makes attaching metadata to geoJSON properties faster by building a nodeIds - geoIds hash beforehand, instead of querying (Object.find) the main nodes dict for each geoJSON node.
This is another 5 seconds :)