### PR TITLE
Feature/select polygons perfs

### DIFF
--- a/scripts/components/map.component.js
+++ b/scripts/components/map.component.js
@@ -115,42 +115,18 @@ export default class {
     console.log(linkedGeoIds.length)
     console.time('looking_up_polys')
     const linkedFeaturesClassNames = {};
-    // const linkedFeatures = linkedGeoIds.map(geoId => {
-    //   const originalPolygon = this.currentPolygonTypeLayer.getLayers().find(polygon => polygon.feature.properties.geoid === geoId);
-    //
-    //   if (originalPolygon !== undefined) {
-    //     // copy class names (ie choropleth from vectorMain's original polygon)
-    //     linkedFeaturesClassNames[geoId] = originalPolygon._path.getAttribute('class');
-    //     return originalPolygon.feature;
-    //   } else {
-    //     // this can potentially happen when geoId doesn't not match polygon type currently visible
-    //     return null;
-    //   }
-    // });
+
     const linkedFeatures = linkedGeoIds.map(geoId => {
-      // const originalPolygon = this.currentPolygonTypeLayer.getLayers().find(polygon => polygon.feature.properties.geoid === geoId);
       const originalPolygon = this.polygonFeaturesDict[geoId];
       if (originalPolygon !== undefined) {
         // copy class names (ie choropleth from vectorMain's original polygon)
-        // linkedFeaturesClassNames[geoId] = originalPolygon._path.getAttribute('class');
-        return originalPolygon;
+        linkedFeaturesClassNames[geoId] = originalPolygon._path.getAttribute('class');
+        return originalPolygon.feature;
       } else {
         // this can potentially happen when geoId doesn't not match polygon type currently visible
         return null;
       }
     });
-
-    // const linkedFeatures = [];
-    // this.currentPolygonTypeLayer.eachLayer(polygon => {
-    //   const geoId = polygon.feature.properties.geoid;
-    //   const geoIdIndex = linkedGeoIds.indexOf(geoId);
-    //   if (geoIdIndex > -1) {
-    //     linkedFeatures.push(polygon.feature);
-    //     // copy class names (ie choropleth from vectorMain's original polygon)
-    //     linkedFeaturesClassNames[geoId] = polygon._path.getAttribute('class');
-    //
-    //   }
-    // });
 
     console.timeEnd('looking_up_polys')
     _.pull(linkedFeatures, null);
@@ -159,9 +135,9 @@ export default class {
       console.time('create_layer')
       this.vectorLinked = L.geoJSON(linkedFeatures, { pane: MAP_PANES.vectorLinked });
       this.map.addLayer(this.vectorLinked);
-      // this.vectorLinked.eachLayer(layer => {
-      //   layer._path.setAttribute('class', linkedFeaturesClassNames[layer.feature.properties.geoid]);
-      // });
+      this.vectorLinked.eachLayer(layer => {
+        layer._path.setAttribute('class', linkedFeaturesClassNames[layer.feature.properties.geoid]);
+      });
       console.timeEnd('create_layer')
 
       this.fitBoundsTimeout = window.setTimeout(() => {
@@ -301,7 +277,7 @@ export default class {
     });
 
     topoLayer.eachLayer(layer => {
-      this.polygonFeaturesDict[layer.feature.properties.geoid] = layer.feature;
+      this.polygonFeaturesDict[layer.feature.properties.geoid] = layer;
       const that = this;
       layer.on({
         mouseover: function() {

--- a/scripts/components/map.component.js
+++ b/scripts/components/map.component.js
@@ -102,18 +102,14 @@ export default class {
 
     window.clearTimeout(this.fitBoundsTimeout);
 
-    console.time('remove')
     if (this.vectorLinked) {
       this.map.removeLayer(this.vectorLinked);
     }
-    console.timeEnd('remove')
 
     if (!linkedGeoIds.length) {
       return;
     }
 
-    console.log(linkedGeoIds.length)
-    console.time('looking_up_polys')
     const linkedFeaturesClassNames = {};
 
     const linkedFeatures = linkedGeoIds.map(geoId => {
@@ -128,22 +124,17 @@ export default class {
       }
     });
 
-    console.timeEnd('looking_up_polys')
     _.pull(linkedFeatures, null);
 
     if (linkedFeatures.length > 0) {
-      console.time('create_layer')
       this.vectorLinked = L.geoJSON(linkedFeatures, { pane: MAP_PANES.vectorLinked });
       this.map.addLayer(this.vectorLinked);
       this.vectorLinked.eachLayer(layer => {
         layer._path.setAttribute('class', linkedFeaturesClassNames[layer.feature.properties.geoid]);
       });
-      console.timeEnd('create_layer')
 
       this.fitBoundsTimeout = window.setTimeout(() => {
-        console.time('fit')
         this.map.fitBounds(this.vectorLinked.getBounds());
-        console.timeEnd('fit')
       }, SANKEY_TRANSITION_TIME);
     }
 
@@ -247,7 +238,6 @@ export default class {
   _createCartoLayer(layerData /*, i */  ) {
     const baseUrl = `${CARTO_BASE_URL}${layerData.layergroupid}/{z}/{x}/{y}`;
     const layerUrl = `${baseUrl}.png`;
-    // console.log(layerUrl)
     const layer = new L.tileLayer(layerUrl, {
       pane: MAP_PANES.context
     });
@@ -268,7 +258,6 @@ export default class {
   }
 
   _getPolygonTypeLayer(geoJSON) {
-    console.time('time')
     var topoLayer = new L.GeoJSON(geoJSON, {
       pane: MAP_PANES.vectorMain,
       style: {
@@ -293,7 +282,6 @@ export default class {
         }
       });
     });
-    console.timeEnd('time')
     return topoLayer;
   }
 

--- a/scripts/components/map.component.js
+++ b/scripts/components/map.component.js
@@ -102,9 +102,11 @@ export default class {
 
     window.clearTimeout(this.fitBoundsTimeout);
 
+    console.time('remove')
     if (this.vectorLinked) {
       this.map.removeLayer(this.vectorLinked);
     }
+    console.timeEnd('remove')
 
     if (!linkedGeoIds.length) {
       return;

--- a/scripts/reducers/flows.reducer.js
+++ b/scripts/reducers/flows.reducer.js
@@ -80,7 +80,6 @@ export default function (state = {}, action) {
     const mapDimensions = getMapDimensions(rawMapDimensions);
 
     const mapDimensionsFolders = mapDimensionsMeta.dimensionGroups;
-
     // store dimension values in nodesDict as uid: dimensionValue
     const nodesDictWithMeta = setNodesMeta(state.nodesDict, nodesMeta, mapDimensions);
 


### PR DESCRIPTION
Makes get_linked_geoids faster by not having a full cross lookup between polygons present in the map and those that should be linked.
It is still too slow for a very big number of polygons (ie Bunge).
The fact that we copy the geometries from the base layer to the linked polygons layer was probably an oversight (I did that for z-ordering - linked layers should always be on top otherwise outlines look 'eaten', and also thinking we'd need drop shadows etc later).
A future fix could be to just change the choropleth colors 'in place' in the base layer. We might want to also look for hiding the linked layer instead of removing it.