### PR TITLE
Links sorting / animation

### DIFF
--- a/scripts/components/map.component.js
+++ b/scripts/components/map.component.js
@@ -108,13 +108,12 @@ export default class {
     // remove choropleth from main layer
     this.map.getPane(MAP_PANES.vectorMain).classList.toggle('-linkedActivated', geoIdList.length);
 
-    window.clearTimeout(this.fitBoundsTimeout);
-
-    if (this.vectorLinked) {
-      this.map.removeLayer(this.vectorLinked);
-    }
+    window.clearTimeout(this.showLinkedFeaturesTimeout);
 
     if (!geoIdList.length) {
+      if (this.vectorLinked) {
+        this.map.removeLayer(this.vectorLinked);
+      }
       return;
     }
 
@@ -134,18 +133,20 @@ export default class {
 
     _.pull(linkedFeatures, null);
 
-    if (linkedFeatures.length > 0) {
-      this.vectorLinked = L.geoJSON(linkedFeatures, { pane: MAP_PANES.vectorLinked });
-      this.map.addLayer(this.vectorLinked);
-      this.vectorLinked.eachLayer(layer => {
-        layer._path.setAttribute('class', linkedFeaturesClassNames[layer.feature.properties.geoid]);
-      });
 
-      this.fitBoundsTimeout = window.setTimeout(() => {
+    this.showLinkedFeaturesTimeout = window.setTimeout(() => {
+      if (this.vectorLinked) {
+        this.map.removeLayer(this.vectorLinked);
+      }
+      if (linkedFeatures.length > 0) {
+        this.vectorLinked = L.geoJSON(linkedFeatures, { pane: MAP_PANES.vectorLinked });
+        this.map.addLayer(this.vectorLinked);
+        this.vectorLinked.eachLayer(layer => {
+          layer._path.setAttribute('class', linkedFeaturesClassNames[layer.feature.properties.geoid]);
+        });
         this.map.fitBounds(this.vectorLinked.getBounds());
-      }, SANKEY_TRANSITION_TIME);
-    }
-
+      }
+    }, SANKEY_TRANSITION_TIME * 1.1);
   }
 
   selectPolygons(payload) { this._outlinePolygons(payload); }

--- a/scripts/components/sankey.component.js
+++ b/scripts/components/sankey.component.js
@@ -204,7 +204,7 @@ export default class {
     const linksData = this.layout.links();
     const links = this.linksContainer
       .selectAll('path')
-      .data(linksData , link => link.id);
+      .data(linksData , link => link.transitionKey);
 
     // update
     links.attr('class', (link) => {return this._getLinkColor(link, selectedRecolorBy); } ); // apply color from CSS class immediately

--- a/scripts/components/sankey.d3layout.js
+++ b/scripts/components/sankey.d3layout.js
@@ -147,12 +147,23 @@ const sankeyLayout = function() {
 
 
     // sort links by node source and target y positions
+    // TODO move sorting to reducer
     links.sort((linkA, linkB) => {
       const sIdAY = stackedHeightsByNodeId.source[linkA.sourceNodeId];
       const sIdBY = stackedHeightsByNodeId.source[linkB.sourceNodeId];
       const tIdAY = stackedHeightsByNodeId.target[linkA.targetNodeId];
       const tIdBY = stackedHeightsByNodeId.target[linkB.targetNodeId];
-      return sIdAY - sIdBY || tIdAY - tIdBY;
+      let sort = sIdAY - sIdBY || tIdAY - tIdBY;
+      if (linkA.ind !== undefined && linkA.ind !== 'none' && linkB.ind !== undefined && linkB.ind !== 'none') {
+        sort = linkA.ind - linkB.ind || sort;
+      }
+      if (linkA.qual !== undefined && linkA.qual !== 'none' && linkB.qual !== undefined && linkB.qual !== 'none') {
+        // sorts alphabetically with quals
+        // TODO use the order presentend in the color by menu
+        sort = linkA.qual.charCodeAt(0) - linkB.qual.charCodeAt(0) || sort;
+      }
+
+      return sort;
     });
 
     links.forEach(link => {

--- a/scripts/components/sankey.d3layout.js
+++ b/scripts/components/sankey.d3layout.js
@@ -132,7 +132,29 @@ const sankeyLayout = function() {
   // compute links y and y deltas (later used by sankey.link generator)
   // will be called at each relayouting (user clicks nodes, user scrolls, etc)
   const _computeLinksCoords = () => {
+
+    // source and target are dicts (nodeIds are keys) containing the cumulated height of all links for each node
     const stackedHeightsByNodeId = {source:{},target:{}};
+
+    // retrieve node ys to bootstrap stackedHeights
+    links.forEach(link => {
+      const sId = link.sourceNodeId;
+      stackedHeightsByNodeId.source[sId] = _getNode(link.sourceColumnPosition, sId).y;
+
+      const tId = link.targetNodeId;
+      stackedHeightsByNodeId.target[tId] = _getNode(link.targetColumnPosition, tId).y;
+    });
+
+
+    // sort links by node source and target y positions
+    links.sort((linkA, linkB) => {
+      const sIdAY = stackedHeightsByNodeId.source[linkA.sourceNodeId];
+      const sIdBY = stackedHeightsByNodeId.source[linkB.sourceNodeId];
+      const tIdAY = stackedHeightsByNodeId.target[linkA.targetNodeId];
+      const tIdBY = stackedHeightsByNodeId.target[linkB.targetNodeId];
+      return sIdAY - sIdBY || tIdAY - tIdBY;
+    });
+
     links.forEach(link => {
       link.width = linksColumnWidth;
       link.x = columnWidth + _getColumnX(link.sourceColumnPosition);
@@ -144,24 +166,12 @@ const sankeyLayout = function() {
       }
 
       const sId = link.sourceNodeId;
-      if (!stackedHeightsByNodeId.source[sId]) stackedHeightsByNodeId.source[sId] = _getNode(link.sourceColumnPosition, sId).y;
       link.sy = stackedHeightsByNodeId.source[sId];
       stackedHeightsByNodeId.source[sId] = link.sy + link.renderedHeight;
 
-      // const sLayerIndex = link.sourceNodeLayerIndex;
-      // if (layerOffsets && layerOffsets[sLayerIndex]) {
-      //   link.sy += layerOffsets[sLayerIndex];
-      // }
-
       const tId = link.targetNodeId;
-      if (!stackedHeightsByNodeId.target[tId]) stackedHeightsByNodeId.target[tId] = _getNode(link.targetColumnPosition, tId).y;
       link.ty = stackedHeightsByNodeId.target[tId];
       stackedHeightsByNodeId.target[tId] = link.ty + link.renderedHeight;
-
-      // const tLayerIndex = link.targetNodeLayerIndex;
-      // if (layerOffsets && layerOffsets[tLayerIndex]) {
-      //   link.ty += layerOffsets[tLayerIndex];
-      // }
     });
   };
 

--- a/scripts/reducers/helpers/mergeLinks.js
+++ b/scripts/reducers/helpers/mergeLinks.js
@@ -10,10 +10,11 @@ export default function(links, userecolorGroups) {
 
     let baseKey = `${link.sourceNodeId}-${link.targetNodeId}`;
     let key;
-    if (userecolorGroups === true) {
-      key = `${baseKey}-colourGroup${link.recolorGroup}`;
-    } else {
+
+    if ((link.qual !== undefined && link.qual !== 'none') || (link.ind !== undefined && link.ind !== 'none')) {
       key = `${baseKey}--${link.qual}-${link.ind}`;
+    } else if (userecolorGroups === true) {
+      key = `${baseKey}-colourGroup${link.recolorGroup}`;
     }
 
     let transitionKey = baseKey;

--- a/scripts/reducers/helpers/mergeLinks.js
+++ b/scripts/reducers/helpers/mergeLinks.js
@@ -8,16 +8,26 @@ export default function(links, userecolorGroups) {
   for (var i = 0; i < links.length; i++) {
     var link = links[i];
 
-    let key = `${link.sourceNodeId}-${link.targetNodeId}`;
+    let baseKey = `${link.sourceNodeId}-${link.targetNodeId}`;
+    let key;
     if (userecolorGroups === true) {
-      key = `${key}-colourGroup${link.recolorGroup}`;
+      key = `${baseKey}-colourGroup${link.recolorGroup}`;
     } else {
-      key = `${key}--${link.qual}-${link.ind}`;
+      key = `${baseKey}--${link.qual}-${link.ind}`;
+    }
+
+    let transitionKey = baseKey;
+    if (link.qual !== undefined && link.qual !== 'none') {
+      transitionKey = `${transitionKey}-${link.qual}`;
+    }
+    if (link.ind !== undefined && link.ind !== 'none') {
+      transitionKey = `${transitionKey}-${link.ind}`;
     }
 
     if (!dict[key]) {
       const mergedLink = _.cloneDeep(link);
       mergedLink.id = key;
+      mergedLink.transitionKey = transitionKey;
       mergedLinks.push(mergedLink);
       dict[key] = mergedLink;
     } else {

--- a/scripts/reducers/helpers/mergeLinks.js
+++ b/scripts/reducers/helpers/mergeLinks.js
@@ -10,11 +10,10 @@ export default function(links, userecolorGroups) {
 
     let baseKey = `${link.sourceNodeId}-${link.targetNodeId}`;
     let key;
-
-    if ((link.qual !== undefined && link.qual !== 'none') || (link.ind !== undefined && link.ind !== 'none')) {
-      key = `${baseKey}--${link.qual}-${link.ind}`;
-    } else if (userecolorGroups === true) {
+    if (userecolorGroups === true) {
       key = `${baseKey}-colourGroup${link.recolorGroup}`;
+    } else {
+      key = `${baseKey}--${link.qual}-${link.ind}`;
     }
 
     let transitionKey = baseKey;

--- a/scripts/reducers/helpers/mergeLinks.js
+++ b/scripts/reducers/helpers/mergeLinks.js
@@ -9,7 +9,7 @@ export default function(links, userecolorGroups) {
     var link = links[i];
 
     let baseKey = `${link.sourceNodeId}-${link.targetNodeId}`;
-    let key;
+    let key = baseKey;
 
     if ((link.qual !== undefined && link.qual !== 'none') || (link.ind !== undefined && link.ind !== 'none')) {
       key = `${baseKey}--${link.qual}-${link.ind}`;


### PR DESCRIPTION
Fixes link sorting to have the least possible links crossing.

Additionally, animations can now be followed more easily, as there will be less nodeA - nodeB links disappearing and then reappearing.

Additionally, fixes a critical bug where links would be merged too aggressively (resulting in incoherent sankeys) when coloring by qual/ind 