### PR TITLE
Fixed regression where legend summary would not appear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 2.0.2
+- Fixed regression where legend summary would not appear
+
 ### 2.0.1
 - Cross browser support improvements
 - Search component refactoring and improvements

--- a/styles/components/shared/nav.scss
+++ b/styles/components/shared/nav.scss
@@ -88,8 +88,8 @@
           }
         }
       }
-
     }
+
   }
 
   .nav-submenu {
@@ -303,5 +303,30 @@
 
   .l-flows & {
     background-color: $white;
+  }
+}
+
+.dropdown-item-legend-summary {
+  display: flex;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+
+  > .color {
+    flex-grow: 1;
+    height: 5px;
+
+    @for $i from 1 through length($qual-colors) {
+      &.#{nth($qual-colors-names, $i)} {
+        background-color: #{nth($qual-colors, $i)};
+      }
+    }
+
+    @for $i from 1 through length($flow-colors) {
+      &.#{nth($flow-colors-names, $i)} {
+        background-color: #{nth($flow-colors, $i)};
+      }
+    }
   }
 }


### PR DESCRIPTION
This

![screen shot 2017-03-23 at 12 07 33](https://cloud.githubusercontent.com/assets/1583415/24244968/5589f17a-0fc1-11e7-93b8-875d6ae01374.png)

is back.