### PR TITLE
Feat/tool nav submenu

### DIFF
--- a/html/includes/_nav.ejs
+++ b/html/includes/_nav.ejs
@@ -7,8 +7,16 @@
               <a href="/" class="nav-link">HOME</a>
             </div>
           <% } %>
-          <div class="nav-item">
-            <a href="/flows.html" class="nav-link">TOOL</a>
+          <div class="nav-item -has-menu">
+            <a class="nav-link">TOOL</a>
+            <ul class="nav-submenu">
+              <li class="nav-submenu-item">
+                <a href="/flows.html" class="nav-link">SUPPLY CHAIN ACTORS</a>
+              </li>
+              <li class="nav-submenu-item">
+                <a href="/flows.html?isMapVisible=true" class="nav-link">PRODUCTION REGIONS</a>
+              </li>
+            </ul>
           </div>
           <div class="<%= page.indexOf('factsheets') !== -1 ? 'nav-item -selected' : 'nav-item' %>">
             <a href="/factsheets.html" class="nav-link">PROFILES</a>

--- a/styles/components/profiles/link-buttons.scss
+++ b/styles/components/profiles/link-buttons.scss
@@ -18,6 +18,16 @@
   color: $charcoal-grey;
   cursor: pointer;
 
+  &:hover {
+    .icon-external-link {
+      fill: $charcoal-grey;
+    }
+
+    &.-with-arrow:after {
+      @include arrow(11px, 1px, $charcoal-grey, 'down');
+    }
+  }
+
   &:before {
     content: '';
     position: absolute;

--- a/styles/components/shared/nav.scss
+++ b/styles/components/shared/nav.scss
@@ -53,6 +53,10 @@
       .nav-link {
         padding-left: 0;
       }
+
+      .nav-submenu-item > .nav-link {
+        padding-left: 16px;
+      }
     }
 
     &:last-child {

--- a/styles/components/shared/nav.scss
+++ b/styles/components/shared/nav.scss
@@ -94,6 +94,9 @@
       }
     }
 
+    &:not(:first-child) .nav-submenu {
+      margin-left: 16px;
+    }
   }
 
   .nav-submenu {
@@ -101,7 +104,6 @@
     position: absolute;
     left: 0;
     top: $nav-height - 11;
-    margin-left: 16px;
     white-space: nowrap;
     background-color: $white;
     box-shadow: 0 10px 20px 0 rgba($charcoal-grey, .2), 0 0 20px 0 rgba($charcoal-grey, .18);


### PR DESCRIPTION
This PR includes the following:
- From #286 : divides the tool nav bar link into a submenu with 2 entries: Flow and Flow w/ map expanded.

**Bonus**:
Addresses the #344 missing hover effect on link buttons.