### PR TITLE
Fix: long names municipality/actor profile

### DIFF
--- a/html/profile-actor.ejs
+++ b/html/profile-actor.ejs
@@ -76,8 +76,7 @@
             <div class="small-4 columns">
               <a href="#profile-content-anchor" class="c-link-buttons -with-arrow js-link-profile">
                 <img src="/images/factsheets/factsheet-main-option-1.svg"/>
-                <svg class="icon icon-search"><use xlink:href="#icon-factsheet-main-option-1"></use></svg>
-                <span class="js-link-button-name">-</span>'s PROFILE
+                <span class="js-link-button-name">-</span>
               </a>
             </div>
             <div class="small-4 columns">

--- a/html/profile-place.ejs
+++ b/html/profile-place.ejs
@@ -119,7 +119,6 @@
             <div class="small-4 columns">
               <a href="#profile-content-anchor" class="c-link-buttons -with-arrow js-link-profile">
                 <img src="/images/factsheets/factsheet-main-option-1.svg"/>
-                <svg class="icon icon-search"><use xlink:href="#icon-factsheet-main-option-1"></use></svg>
                 <span class="js-link-button-municipality">-</span>
               </a>
             </div>

--- a/html/profile-place.ejs
+++ b/html/profile-place.ejs
@@ -120,7 +120,7 @@
               <a href="#profile-content-anchor" class="c-link-buttons -with-arrow js-link-profile">
                 <img src="/images/factsheets/factsheet-main-option-1.svg"/>
                 <svg class="icon icon-search"><use xlink:href="#icon-factsheet-main-option-1"></use></svg>
-                <span class="js-link-button-municipality">-</span>'s PROFILE
+                <span class="js-link-button-municipality">-</span>
               </a>
             </div>
             <div class="small-4 columns">

--- a/scripts/components/profiles/chord.component.js
+++ b/scripts/components/profiles/chord.component.js
@@ -14,13 +14,13 @@ export default class {
     document.querySelector(className).classList.remove('is-hidden');
 
     const nameLimit = 11;
-    const allNames = [placeName].concat(list.map(node => {
+    const allNames = [{ name: placeName }].concat(list).map(node => {
       if (node.name.length > nameLimit) {
         return `${node.name.substring(0, nameLimit)}...`;
       } else {
         return node.name;
       }
-    })).slice(0, orgMatrix.length);
+    }).slice(0, orgMatrix.length);
 
     const elem = document.querySelector(className);
     const margin = {top: 0, right: 0, bottom: 0, left: 0};

--- a/scripts/pages/profile-actor.page.js
+++ b/scripts/pages/profile-actor.page.js
@@ -22,6 +22,7 @@ import MultiTable from 'components/profiles/multi-table.component';
 
 import { getURLParams } from 'utils/stateURL';
 import smoothScroll from 'utils/smoothScroll';
+import formatApostrophe from 'utils/formatApostrophe';
 import _ from 'lodash';
 import { getURLFromParams, GET_ACTOR_FACTSHEET } from '../utils/getURLFromParams';
 
@@ -104,7 +105,7 @@ const _build = data => {
     new MultiTable({
       el: document.querySelector('.js-sustainability-table'),
       data: data.sustainability,
-      tabsTitle: `Sustainability of ${data.node_name}\'s TOP source regions in 2015:`,
+      tabsTitle: `Sustainability of ${formatApostrophe(data.node_name)} TOP source regions in 2015:`,
       type: 't_head_actors',
       target: 'actor'
     });
@@ -112,9 +113,8 @@ const _build = data => {
 };
 
 const _setInfo = (info, nodeId) => {
-  document.querySelector('.js-name').innerHTML =
-    document.querySelector('.js-link-button-name').innerHTML =
-    info.name ? _.capitalize(info.name) : '-';
+  document.querySelector('.js-name').innerHTML = info.name ? _.capitalize(info.name) : '-';
+  document.querySelector('.js-link-button-name').innerHTML = formatApostrophe(_.capitalize(info.name)) + ' PROFILE';
   document.querySelector('.js-legend').innerHTML = info.type || '-';
   document.querySelector('.js-country').innerHTML = info.country ? _.capitalize(info.country) : '-';
   if (info.forest_500 > 0) document.querySelector('.js-forest-500-score .circle-icon[data-value="1"] use').setAttributeNS('http://www.w3.org/1999/xlink', 'href', '#icon-circle-filled');

--- a/scripts/pages/profile-actor.page.js
+++ b/scripts/pages/profile-actor.page.js
@@ -114,7 +114,7 @@ const _build = data => {
 
 const _setInfo = (info, nodeId) => {
   document.querySelector('.js-name').innerHTML = info.name ? _.capitalize(info.name) : '-';
-  document.querySelector('.js-link-button-name').innerHTML = formatApostrophe(_.capitalize(info.name)) + ' PROFILE';
+  document.querySelector('.js-link-button-name').textContent = formatApostrophe(_.capitalize(info.name)) + ' PROFILE';
   document.querySelector('.js-legend').innerHTML = info.type || '-';
   document.querySelector('.js-country').innerHTML = info.country ? _.capitalize(info.country) : '-';
   if (info.forest_500 > 0) document.querySelector('.js-forest-500-score .circle-icon[data-value="1"] use').setAttributeNS('http://www.w3.org/1999/xlink', 'href', '#icon-circle-filled');

--- a/scripts/pages/profile-place.page.js
+++ b/scripts/pages/profile-place.page.js
@@ -32,7 +32,6 @@ const defaults = {
   commodity: 'Soy'
 };
 
-
 const _build = data => {
   const stateGeoID = data.state_geoId;
 
@@ -83,7 +82,7 @@ const _build = data => {
     new Top({
       el: document.querySelector('.js-top-consumer'),
       data: data.top_consumers.countries,
-      title: `Top consumers of ${data.municip_name}'s soy`,
+      title: `Top consumers of ${_formatApostrophe(data.municip_name)} soy`,
       unit: '%'
     });
 
@@ -123,9 +122,17 @@ const _setInfo = (info, nodeId) => {
   document.querySelector('.js-link-supply-chain').setAttribute('href', `./flows.html?selectedNodesIds=[${nodeId}]`);
   document.querySelector('.js-line-title').innerHTML = info.municipality ? `Deforestation trajectory of ${info.municipality}` : '-';
   document.querySelector('.js-summary-text').innerHTML = info.summary ? info.summary : '-';
-  document.querySelector('.js-municipality').innerHTML =
-    document.querySelector('.js-link-button-municipality').innerHTML =
-    info.municipality ? _.capitalize(info.municipality) : '-';
+  document.querySelector('.js-municipality').innerHTML = info.municipality;
+  document.querySelector('.js-link-button-municipality').textContent = _formatApostrophe(info.municipality) + ' PROFILE';
+
+};
+
+const  _formatApostrophe = (text) => {
+  if (text) {
+    const name =_.capitalize(text);
+    return _.endsWith(name, 's') ? name + '\'' : name + '\'s';
+  }
+  return '-';
 };
 
 const _setEventListeners = () => {

--- a/scripts/pages/profile-place.page.js
+++ b/scripts/pages/profile-place.page.js
@@ -22,6 +22,7 @@ import MultiTable from 'components/profiles/multi-table.component';
 import Map from 'components/profiles/map.component';
 
 import { getURLParams } from 'utils/stateURL';
+import formatApostrophe from 'utils/formatApostrophe';
 import formatNumber from 'utils/formatNumber';
 import smoothScroll from 'utils/smoothScroll';
 import _ from 'lodash';
@@ -82,7 +83,7 @@ const _build = data => {
     new Top({
       el: document.querySelector('.js-top-consumer'),
       data: data.top_consumers.countries,
-      title: `Top consumers of ${_formatApostrophe(data.municip_name)} soy`,
+      title: `Top consumers of ${formatApostrophe(_.capitalize(data.municip_name))} soy`,
       unit: '%'
     });
 
@@ -122,17 +123,9 @@ const _setInfo = (info, nodeId) => {
   document.querySelector('.js-link-supply-chain').setAttribute('href', `./flows.html?selectedNodesIds=[${nodeId}]`);
   document.querySelector('.js-line-title').innerHTML = info.municipality ? `Deforestation trajectory of ${info.municipality}` : '-';
   document.querySelector('.js-summary-text').innerHTML = info.summary ? info.summary : '-';
-  document.querySelector('.js-municipality').innerHTML = info.municipality;
-  document.querySelector('.js-link-button-municipality').textContent = _formatApostrophe(info.municipality) + ' PROFILE';
+  document.querySelector('.js-municipality').innerHTML = info.municipality ? info.municipality : '-';
+  document.querySelector('.js-link-button-municipality').textContent = formatApostrophe(_.capitalize(info.municipality)) + ' PROFILE';
 
-};
-
-const  _formatApostrophe = (text) => {
-  if (text) {
-    const name =_.capitalize(text);
-    return _.endsWith(name, 's') ? name + '\'' : name + '\'s';
-  }
-  return '-';
 };
 
 const _setEventListeners = () => {

--- a/scripts/utils/formatApostrophe.js
+++ b/scripts/utils/formatApostrophe.js
@@ -1,0 +1,7 @@
+export default (text) => {
+  if (text) {
+    debugger
+    return text.substr(-1, 1).toLowerCase() === 's' ? text + '\'' : text + '\'s';
+  }
+  return '-';
+};

--- a/scripts/utils/formatApostrophe.js
+++ b/scripts/utils/formatApostrophe.js
@@ -1,6 +1,5 @@
 export default (text) => {
   if (text) {
-    debugger
     return text.substr(-1, 1).toLowerCase() === 's' ? text + '\'' : text + '\'s';
   }
   return '-';


### PR DESCRIPTION
This PR addresses the following issue(s):
- [x] removes invisible search icon that was occupying space inside `link-button`.
- [x] formats texts that contain an `'s` in the end to prevent in the case where the name ends with `s`.
- [x] fixes text breaking in `link-button` when the name is too long.
- [x] fixes broken text in chords diagram when name is too long.