### PR TITLE
Feature/map tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- tool: added tooltips on the map to show info that is otherwise displayed on the bottom of the sankey
 - tool: added link tooltips resize by information
 - tool: added link tooltips quant units
 - profiles: added hover effects on shortcut buttons

--- a/html/profile-actor.ejs
+++ b/html/profile-actor.ejs
@@ -135,7 +135,7 @@
         <p class="message">Data not found</p>
       </div>
     </div>
-    <div class="js-infowindow c-profile-tooltip is-hidden"></div>
+    <div class="js-infowindow c-info-tooltip is-hidden"></div>
     <%= htmlWebpackPlugin.options.footer %>
   </div>
   <%= htmlWebpackPlugin.options.scripts %>

--- a/html/tool.ejs
+++ b/html/tool.ejs
@@ -6,6 +6,7 @@
 </head>
 <body>
   <div class="tooltip-layout is-hidden"></div>
+  <div class="js-tool-tooltip c-info-tooltip"></div>
   <div class="loading-wrapper">
     <%= htmlWebpackPlugin.options.icons %>
     <div class="l-flows">
@@ -70,8 +71,6 @@
         <div id="js-columns-selector-react"></div>
 
         <div class="c-sankey is-absolute js-sankey">
-          <div class="js-sankey-tooltip c-info-tooltip"></div>
-
           <svg class="js-sankey-canvas sankey">
             <defs>
               <pattern id="isAggregatedPattern" x="0" y="0" width="1" height="3" patternUnits="userSpaceOnUse">

--- a/html/tool.ejs
+++ b/html/tool.ejs
@@ -70,7 +70,7 @@
         <div id="js-columns-selector-react"></div>
 
         <div class="c-sankey is-absolute js-sankey">
-          <div class="js-sankey-tooltip c-profile-tooltip"></div>
+          <div class="js-sankey-tooltip c-info-tooltip"></div>
 
           <svg class="js-sankey-canvas sankey">
             <defs>
@@ -99,7 +99,7 @@
           </svg>
           <div class="expand-button js-expand">
             <svg class="icon icon-outside-link"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-more-options"></use></svg>
-            <div class="c-sankey-tooltip">
+            <div class="c-node-menu">
               <ul class="actions">
                 <li class="expand-action js-expand-action" data-collapsed-text="EXPAND SELECTED NODES" data-expanded-text="COLLAPSE SELECTED NODES">
                   <svg class="icon"><use xlink:href="#icon-more-options"></use></svg>

--- a/scripts/actions/tool.actions.js
+++ b/scripts/actions/tool.actions.js
@@ -404,7 +404,7 @@ export function selectNodeFromGeoId(geoId) {
   };
 }
 
-export function highlightNode(nodeId, isAggregated) {
+export function highlightNode(nodeId, isAggregated, coordinates) {
   return (dispatch, getState) => {
     if (isAggregated) {
       return;
@@ -412,14 +412,15 @@ export function highlightNode(nodeId, isAggregated) {
 
     const action = getNodesSelectionAction([nodeId], getState().tool);
     action.type = actions.HIGHLIGHT_NODE;
+    action.coordinates = coordinates;
     dispatch(action);
   };
 }
 
-export function highlightNodeFromGeoId(geoId) {
+export function highlightNodeFromGeoId(geoId, coordinates) {
   return (dispatch, getState) => {
     const nodeId = getNodeIdFromGeoId(geoId, getState().tool.nodesDict, getState().tool.selectedColumnsIds[0]);
-    dispatch(highlightNode(nodeId, false));
+    dispatch(highlightNode(nodeId, false, coordinates));
   };
 }
 

--- a/scripts/components/profiles/tooltip.component.js
+++ b/scripts/components/profiles/tooltip.component.js
@@ -1,5 +1,5 @@
 import TooltipTemplate from 'ejs!templates/shared/tooltip.ejs';
-import 'styles/components/shared/infowindow.scss';
+import 'styles/components/shared/info-tooltip.scss';
 
 export default class {
   constructor(className) {

--- a/scripts/components/tool/map.component.js
+++ b/scripts/components/tool/map.component.js
@@ -287,8 +287,8 @@ export default class {
       this.polygonFeaturesDict[layer.feature.properties.geoid] = layer;
       const that = this;
       layer.on({
-        mouseover: function() {
-          that.callbacks.onPolygonHighlighted(this.feature.properties.geoid);
+        mouseover: function(event) {
+          that.callbacks.onPolygonHighlighted(this.feature.properties.geoid, { pageX: event.originalEvent.pageX, pageY: event.originalEvent.pageY});
         },
         mouseout: function() {
           that.callbacks.onPolygonHighlighted();

--- a/scripts/components/tool/nodesTitles.component.js
+++ b/scripts/components/tool/nodesTitles.component.js
@@ -1,22 +1,37 @@
+import _ from 'lodash';
 import NodeTitleTemplate from 'ejs!templates/tool/nodeTitle.ejs';
 import 'styles/components/tool/nodesTitles.scss';
+import TooltipTemplate from 'ejs!templates/shared/tooltip.ejs';
 
 export default class {
   onCreated() {
     this.el = document.querySelector('.js-nodes-titles');
+    this.tooltip = document.querySelector('.js-tool-tooltip');
+    this.tooltipHideDebounced = _.debounce(this._hideTooltip, 10);
   }
 
   selectNodes(data) {
     this._update(true, data.nodesData, data.recolorGroups);
   }
 
-  highlightNode(data) {
-    this._update(!data.isHighlight, data.nodesData, data.recolorGroups);
+  highlightNode({ isHighlight, nodesData, recolorGroups, coordinates, isMapVisible }) {
+    // when map is full screen, show data as a tooltip instead of a nodeTitle
+    if (coordinates !== undefined && isMapVisible === true) {
+      this._showTooltip(nodesData, coordinates);
+    } else {
+      this.tooltipHideDebounced();
+
+      // TODO nodesData[0] === undefined should never happen, this is a smell form the reducer
+      if (nodesData === undefined || nodesData.length === 0 || nodesData[0] === undefined) {
+        this.el.classList.add('is-hidden');
+      } else {
+        this.el.classList.remove('is-hidden');
+        this._update(!isHighlight, nodesData, recolorGroups);
+      }
+    }
   }
 
   _update(isSelect, nodesData, recolorGroups = null) {
-    // TODO nodesData[0] === undefined should never happen, this is a smell form the reducer
-    if (nodesData === undefined || nodesData.length === 0 || nodesData[0] === undefined) return;
     this.el.innerHTML = NodeTitleTemplate({
       nodes: nodesData,
       isSelect: isSelect || nodesData.length > 1,
@@ -39,5 +54,48 @@ export default class {
         this.callbacks.onCloseNodeClicked(parseInt(e.currentTarget.dataset.nodeId));
       });
     });
+  }
+
+  _showTooltip(nodesData, coordinates) {
+    this.tooltipHideDebounced.cancel();
+    const node = nodesData[0];
+
+    if (node.selectedMetas === undefined) {
+      return;
+    }
+
+    const templateValues = {
+      title: node.name,
+      values: []
+    };
+
+    // map metas might not be loaded yet
+    if (node.selectedMetas !== undefined) {
+      templateValues.values = node.selectedMetas.map(meta => {
+        return {
+          title: meta.name,
+          unit: meta.unit,
+          value: meta.rawValueNice,
+        };
+      }).concat(templateValues.values);
+    }
+
+    // if node is visible in sankey, quant is available
+    if (node.quantName !== undefined) {
+      templateValues.values.push({
+        title: node.quantName,
+        unit: node.quantUnit,
+        value: node.quantNice
+      });
+    }
+
+    this.tooltip.innerHTML = TooltipTemplate(templateValues);
+    this.tooltip.classList.remove('is-hidden');
+    this.tooltip.style.left = `${coordinates.pageX + 10}px`;
+    this.tooltip.style.top = `${coordinates.pageY + 10}px`;
+  }
+
+  _hideTooltip() {
+    this.tooltip.classList.add('is-hidden');
   }
 }

--- a/scripts/components/tool/nodesTitles.component.js
+++ b/scripts/components/tool/nodesTitles.component.js
@@ -16,15 +16,17 @@ export default class {
 
   highlightNode({ isHighlight, nodesData, recolorGroups, coordinates, isMapVisible }) {
     // when map is full screen, show data as a tooltip instead of a nodeTitle
-    if (coordinates !== undefined && isMapVisible === true) {
+    if (coordinates !== undefined) {
       this._showTooltip(nodesData, coordinates);
     } else {
       this.tooltipHideDebounced();
+    }
 
-      // TODO nodesData[0] === undefined should never happen, this is a smell form the reducer
-      if (nodesData === undefined || nodesData.length === 0 || nodesData[0] === undefined) {
-        this.el.classList.add('is-hidden');
-      } else {
+    // TODO nodesData[0] === undefined should never happen, this is a smell form the reducer
+    if (nodesData === undefined || nodesData.length === 0 || nodesData[0] === undefined) {
+      this.el.classList.add('is-hidden');
+    } else {
+      if (isMapVisible === false) {
         this.el.classList.remove('is-hidden');
         this._update(!isHighlight, nodesData, recolorGroups);
       }

--- a/scripts/components/tool/sankey.component.js
+++ b/scripts/components/tool/sankey.component.js
@@ -89,8 +89,8 @@ export default class {
     this.sankeyColumns = this.svg.selectAll('.sankey-column');
     this.linksContainer = this.svg.select('.sankey-links');
 
-    this.linkTooltip = document.querySelector('.js-sankey-tooltip');
-    this.linkTooltipHideDebounced = _.debounce(function() { document.querySelector('.js-sankey-tooltip').classList.add('is-hidden'); }, 10);
+    this.linkTooltip = document.querySelector('.js-tool-tooltip');
+    this.linkTooltipHideDebounced = _.debounce(this._onLinkOut, 10);
 
     this.sankeyColumns.on('mouseleave', () => { this._onColumnOut(); } );
 
@@ -294,9 +294,13 @@ export default class {
 
     this.linkTooltip.innerHTML = TooltipTemplate(templateValues);
     this.linkTooltip.classList.remove('is-hidden');
-    this.linkTooltip.style.left = d3_event.offsetX + 'px';
-    this.linkTooltip.style.top = d3_event.offsetY + 'px';
+    this.linkTooltip.style.left = `${d3_event.pageX + 10}px`;
+    this.linkTooltip.style.top = `${d3_event.pageY + 10}px`;
     linkEl.classList.add('-hover');
+  }
+
+  _onLinkOut() {
+    this.linkTooltip.classList.add('is-hidden');
   }
 
   _onColumnOut() {

--- a/scripts/components/tool/sankey.component.js
+++ b/scripts/components/tool/sankey.component.js
@@ -7,7 +7,8 @@ import addSVGDropShadowDef from 'utils/addSVGDropShadowDef';
 import sankeyLayout from './sankey.d3layout.js';
 import 'styles/components/tool/sankey.scss';
 import TooltipTemplate from 'ejs!templates/shared/tooltip.ejs';
-import 'styles/components/shared/infowindow.scss';
+import 'styles/components/shared/info-tooltip.scss';
+import 'styles/components/tool/node-menu.scss';
 
 
 export default class {

--- a/scripts/containers/tool/map.container.js
+++ b/scripts/containers/tool/map.container.js
@@ -56,7 +56,7 @@ const mapMethodsToState = (state) => ({
 
 const mapViewCallbacksToActions = () => ({
   onPolygonClicked: geoId => selectNodeFromGeoId(geoId),
-  onPolygonHighlighted: geoId => highlightNodeFromGeoId(geoId),
+  onPolygonHighlighted: (geoId, coordinates) => highlightNodeFromGeoId(geoId, coordinates),
   onToggleMap: () => toggleMap(),
   onToggleMapLayerMenu: () => toggleMapLayerMenu(),
   onMoveEnd: (latlng, zoom) => saveMapView(latlng, zoom)

--- a/scripts/containers/tool/nodesTitles.container.js
+++ b/scripts/containers/tool/nodesTitles.container.js
@@ -15,7 +15,9 @@ const mapMethodsToState = (state) => ({
       return {
         nodesData: (state.tool.highlightedNodeData.length === 0) ? state.tool.selectedNodesData : state.tool.highlightedNodeData,
         isHighlight: state.tool.highlightedNodeData.length > 0,
-        recolorGroups: state.tool.recolorGroups
+        recolorGroups: state.tool.recolorGroups,
+        coordinates: state.tool.highlightedNodeCoordinates,
+        isMapVisible: state.tool.isMapVisible
       };
     }
   }

--- a/scripts/reducers/tool.reducer.js
+++ b/scripts/reducers/tool.reducer.js
@@ -257,7 +257,8 @@ export default function (state = {}, action) {
       newState = Object.assign({}, state, {
         highlightedNodesIds: action.ids,
         highlightedNodeData: action.data,
-        highlightedGeoIds: action.geoIds
+        highlightedGeoIds: action.geoIds,
+        highlightedNodeCoordinates: action.coordinates
       });
       break;
     }

--- a/styles/components/shared/info-tooltip.scss
+++ b/styles/components/shared/info-tooltip.scss
@@ -1,51 +1,6 @@
 @import '../../settings';
 
-.c-sankey-tooltip {
-  position: absolute;
-  width: 200px;
-  box-shadow: $box-shadow-big;
-  font-family: $font-family-1;
-
-  > .title {
-    padding: 10px;
-    background-color: $manilla;
-    letter-spacing: -1px;
-    font-family: $font-family-1;
-  }
-
-  > .body {
-    padding: 10px;
-    background-color: $white;
-  }
-
-  .actions {
-
-    li {
-      position: relative;
-      height: 32px;
-      padding: 11px 8px;
-      font-size: 12px;
-      letter-spacing: -0.6px;
-      color: $charcoal-grey;
-      background-color: $white;
-      cursor: pointer;
-
-      > .icon {
-        position: absolute;
-        top: 8px;
-        right: 10px;
-        width: 16px;
-        height: 16px;
-      }
-
-      &:hover {
-        background-color: $manilla;
-      }
-    }
-  }
-}
-
-.c-profile-tooltip {
+.c-info-tooltip {
   position: absolute;
   box-shadow: $box-shadow-big;
   font-family: $font-family-1;

--- a/styles/components/shared/info-tooltip.scss
+++ b/styles/components/shared/info-tooltip.scss
@@ -6,6 +6,7 @@
   font-family: $font-family-1;
   background-color: $white;
   color: $charcoal-grey;
+  z-index: 99;
 
   > .title {
     font-family: $font-family-1;

--- a/styles/components/tool/node-menu.scss
+++ b/styles/components/tool/node-menu.scss
@@ -1,0 +1,46 @@
+@import '../../settings';
+
+.c-node-menu {
+  position: absolute;
+  width: 200px;
+  box-shadow: $box-shadow-big;
+  font-family: $font-family-1;
+
+  > .title {
+    padding: 10px;
+    background-color: $manilla;
+    letter-spacing: -1px;
+    font-family: $font-family-1;
+  }
+
+  > .body {
+    padding: 10px;
+    background-color: $white;
+  }
+
+  .actions {
+
+    li {
+      position: relative;
+      height: 32px;
+      padding: 11px 8px;
+      font-size: 12px;
+      letter-spacing: -0.6px;
+      color: $charcoal-grey;
+      background-color: $white;
+      cursor: pointer;
+
+      > .icon {
+        position: absolute;
+        top: 8px;
+        right: 10px;
+        width: 16px;
+        height: 16px;
+      }
+
+      &:hover {
+        background-color: $manilla;
+      }
+    }
+  }
+}

--- a/styles/components/tool/sankey.scss
+++ b/styles/components/tool/sankey.scss
@@ -110,7 +110,7 @@
       margin: auto;
     }
 
-    .c-sankey-tooltip {
+    .c-node-menu {
       display: none;
       top: 2px;
       right: 0;
@@ -134,7 +134,7 @@
     &:hover {
       background-color: transparent;
       box-shadow: unset;
-      .c-sankey-tooltip {
+      .c-node-menu {
         display: block;
       }
     }


### PR DESCRIPTION
When map is expanded, show info related to node as a tooltip directly on the map instead of below sankey.

![trase-map-tooltips](https://cloud.githubusercontent.com/assets/1583415/25669357/91bd9e0c-3029-11e7-8e94-dee685fccad4.gif)
