### PR TITLE
Charts + Choropleths tune-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- profiles: fixes scatterplot not showing current node.
+- profiles: fixes municipalities legend not showing when switching source.
 - profiles: includes map choropleth legend
 - profiles: includes the top sources' source switch.
 - tool: map dimensions groups are now collapsible

--- a/scripts/components/profiles/choro-legend.component.js
+++ b/scripts/components/profiles/choro-legend.component.js
@@ -3,7 +3,9 @@ import 'style/components/tool/map/map-legend.scss';
 import { PROFILE_CHOROPLETH_CLASSES } from 'constants';
 import abbreviateNumber from 'utils/abbreviateNumber';
 
-export default (selector, { title, bucket }) => {
+export default (selector, legend, { title, bucket }) => {
+  const el = document.querySelector(selector);
+
   const legendTemplate = LegendChoroTemplate({
     title,
     cssClass: '-horizontal -profile',
@@ -13,7 +15,7 @@ export default (selector, { title, bucket }) => {
     isBidimensional: false
   });
 
-  const container = document.querySelector(selector);
+  const container = el.querySelector(legend);
   container.classList.add('c-map-legend-choro');
   container.innerHTML = legendTemplate;
 };

--- a/scripts/components/profiles/choro-legend.component.js
+++ b/scripts/components/profiles/choro-legend.component.js
@@ -5,6 +5,7 @@ import abbreviateNumber from 'utils/abbreviateNumber';
 
 export default (selector, legend, { title, bucket }) => {
   const el = document.querySelector(selector);
+  el.classList.add('-with-legend');
 
   const legendTemplate = LegendChoroTemplate({
     title,

--- a/scripts/components/profiles/map.component.js
+++ b/scripts/components/profiles/map.component.js
@@ -79,7 +79,7 @@ export default (className, { topoJSONPath, topoJSONRoot, getPolygonClassName, sh
 
   if (legend) {
     d3Container.append('div').attr('class', 'legend-container');
-    choroLegend('.legend-container', legend);
+    choroLegend(className, '.legend-container', legend);
   }
 
 };

--- a/scripts/components/profiles/map.component.js
+++ b/scripts/components/profiles/map.component.js
@@ -25,6 +25,7 @@ function fitGeoInside(featureBounds, width, height) {
 
 export default (className, { topoJSONPath, topoJSONRoot, getPolygonClassName, showTooltipCallback, hideTooltipCallback, useRobinsonProjection, legend }) => {
   const d3Container =  d3_select(className);
+  d3Container.node().classList.remove('-with-legend');
   const containerComputedStyle = window.getComputedStyle(d3Container.node());
   const width = parseInt(containerComputedStyle.width);
   const height = parseInt(containerComputedStyle.height);

--- a/scripts/components/profiles/scatterplot.component.js
+++ b/scripts/components/profiles/scatterplot.component.js
@@ -29,7 +29,7 @@ export default class {
   }
 
   _render() {
-    const margin = { top: 4, right: 13, bottom: 30, left: 29 };
+    const margin = { top: 20, right: 13, bottom: 30, left: 29 };
     this.width = this.el.clientWidth - margin.left - margin.right;
     this.height = 377 - margin.top - margin.bottom;
     let allYValues = this.data.map(item => item.y);

--- a/scripts/components/profiles/scatterplot.component.js
+++ b/scripts/components/profiles/scatterplot.component.js
@@ -20,7 +20,7 @@ export default class {
     this.switcherEl = document.querySelector('.js-scatterplot-switcher');
     this.data = settings.data;
     this.xDimension = settings.xDimension;
-    this.nodeId = settings.nodeId;
+    this.node = settings.node;
     this.showTooltipCallback = settings.showTooltipCallback;
     this.hideTooltipCallback = settings.hideTooltipCallback;
 
@@ -92,7 +92,7 @@ export default class {
       .data(this._getFormatedData(0))
       .enter()
       .append('circle')
-      .attr('class', (function(d) { return d.nodeId.toString() === this.nodeId ? 'dot current' : 'dot'; }).bind(this))
+      .attr('class', (function(d) { return d.name.toUpperCase() === this.node.name.toUpperCase() ? 'dot current' : 'dot'; }).bind(this))
       .attr('r', 5)
       .attr('cx', function(d) { return this.x(d.x); }.bind(this))
       .attr('cy', function(d) { return this.y(d.y); }.bind(this));

--- a/scripts/pages/profile-actor.page.js
+++ b/scripts/pages/profile-actor.page.js
@@ -76,7 +76,7 @@ const _build = (data, nodeId) => {
       '.js-top-municipalities',
       topMunicipalitiesLines,
       data.top_sources.included_years,
-      Object.assign({}, lineSettings, { margin: {top: 10, right: 100, bottom: 25, left: 37 } }),
+      Object.assign({}, lineSettings, { margin: { top: 10, right: 100, bottom: 25, left: 37 } }),
     );
 
     Map('.js-top-municipalities-map', {
@@ -176,7 +176,7 @@ const _build = (data, nodeId) => {
   new Scatterplot('.js-companies-exporting', {
     data: data.companies_exporting.companies,
     xDimension: data.companies_exporting.dimensions_x,
-    nodeId: nodeId,
+    node: { id: nodeId, name: data.node_name },
     showTooltipCallback: (company, indicator, x, y) => {
       tooltip.showTooltip(x, y, {
         title: company.name,

--- a/scripts/pages/profile-actor.page.js
+++ b/scripts/pages/profile-actor.page.js
@@ -298,8 +298,8 @@ const _switchTopSource = (e, data) => {
     getPolygonClassName: ({ properties }) => {
       const source = data.top_sources[selectedSource].lines
         .find(s => (properties.geoid === s.geo_id));
-      let value = 0;
-      if (source) value = source.value9 || 0;
+      let value = 'n-a';
+      if (source) value = source.value9 || 'n-a';
       return `-outline ch-${value}`;
     },
     showTooltipCallback: ({ properties }, x, y) => {
@@ -320,6 +320,10 @@ const _switchTopSource = (e, data) => {
     },
     hideTooltipCallback: () => {
       tooltip.hideTooltip();
+    },
+    legend: {
+      title: ['Soy exported in 2015', '(t)'],
+      bucket: [data.top_sources.buckets[0], ...data.top_sources.buckets]
     }
   });
 };

--- a/styles/layouts/l-profile-actor.scss
+++ b/styles/layouts/l-profile-actor.scss
@@ -98,6 +98,10 @@
 
     .js-top-municipalities-map {
       height: 405px;
+
+      &.-with-legend {
+        height: 480px;
+      }
     }
   }
 


### PR DESCRIPTION
This PR addresses the following issue(s):
- The dissappearing of the legend, when switching the municipalities source. this was due to the legend always rendering in the countries `.legend-container` div instead of on the municipalities one.
- Changes the scatterplot component to do a comparison based on the name of the node, because same actors have different nodeid's when they are both exporters and importers.