### PR TITLE
Fix: hide null dots scatterplot

### DIFF
--- a/scripts/components/profiles/scatterplot.component.js
+++ b/scripts/components/profiles/scatterplot.component.js
@@ -92,10 +92,10 @@ export default class {
       .data(this._getFormatedData(0))
       .enter()
       .append('circle')
-      .attr('class', (function(d) { return d.name.toUpperCase() === this.node.name.toUpperCase() ? 'dot current' : 'dot'; }).bind(this))
+      .attr('class', d => this._getCircleClass(d))
       .attr('r', 5)
-      .attr('cx', function(d) { return this.x(d.x); }.bind(this))
-      .attr('cy', function(d) { return this.y(d.y); }.bind(this));
+      .attr('cx', d => this.x(d.x))
+      .attr('cy', d => this.y(d.y));
 
     if (this.showTooltipCallback !== undefined) {
       this.circles.on('mousemove', function(d) {
@@ -151,7 +151,8 @@ export default class {
       .data(newData)
       .transition()
       .duration(700)
-      .attr('cx', function(d) { return x(d.x); });
+      .attr('cx', d => x(d.x))
+      .attr('class', d => (d.x === null ? `${this._getCircleClass(d)} -hidden` : this._getCircleClass(d)));
 
     this.svg.select('.axis--x')
       .transition()
@@ -168,5 +169,9 @@ export default class {
         x: item.x[i]
       };
     });
+  }
+
+  _getCircleClass(d) {
+    return d.name.toUpperCase() === this.node.name.toUpperCase() ? 'dot current' : 'dot';
   }
 }

--- a/styles/components/profiles/scatterplot.scss
+++ b/styles/components/profiles/scatterplot.scss
@@ -45,6 +45,7 @@
     fill: $charcoal-grey;
     stroke: $egg-shell;
     stroke-width: 2;
+    transition: opacity 150ms linear;
 
     &:hover {
       fill: $medium-pink;
@@ -54,6 +55,10 @@
       fill: $medium-pink;
       stroke: rgba($medium-pink, .4);
       stroke-width: 16px;
+    }
+
+    &.-hidden {
+      opacity: 0;
     }
   }
 


### PR DESCRIPTION
This PR addresses the following issue(s):
- In the scatterplot when dots were null they appeared in the `x = 0` position. Now they're hidden when they don't have data.