### PR TITLE
fixed switch column on search

### DIFF
--- a/scripts/actions/tool.actions.js
+++ b/scripts/actions/tool.actions.js
@@ -439,15 +439,14 @@ export function searchNode(nodeId) {
 
       // check if we need to swap column
       const node = getState().tool.nodesDict[nodeId];
-      const columnPos = node.columnPosition;
-      const currentColumnAtPos = getState().tool.selectedColumnsIds[columnPos];
-
+      const columnGroup = node.columnGroup;
+      const currentColumnAtPos = getState().tool.selectedColumnsIds[columnGroup];
       if (!node) {
         console.warn(`requested node ${nodeId} does not exist in nodesDict`);
         return;
       }
       if (currentColumnAtPos !== node.columnId) {
-        dispatch(selectColumn(columnPos, node.columnId, false));
+        dispatch(selectColumn(columnGroup, node.columnId, false));
       }
       // 1. before: go to detailed mode and select
       // dispatch(selectView(true));

--- a/scripts/reducers/helpers/getNodesDict.js
+++ b/scripts/reducers/helpers/getNodesDict.js
@@ -15,10 +15,8 @@ export default function (rawNodes, columns /*, nodesMeta*/) {
       type: column.name,
       columnGroup: column.group,
       isDefault: column.isDefault,
-      columnPosition: column.position,
       name: node.name,
       geoId: node.geoId
-      // inds: []
     };
 
     if (node.isDomesticConsumption === true || node.isDomesticConsumption === 'true') {

--- a/scripts/reducers/helpers/splitVisibleNodesByColumn.js
+++ b/scripts/reducers/helpers/splitVisibleNodesByColumn.js
@@ -3,7 +3,7 @@ import { nest as d3_nest } from 'd3-collection';
 export default function(nodes) {
   const columns = d3_nest()
   .key(el => {
-    return el.columnPosition;
+    return el.columnGroup;
   })
   .sortKeys((a, b) => {
     return (parseInt(a) < parseInt(b)) ? -1 : 1;


### PR DESCRIPTION
Fixes an issue that prevented a column switch when for example, looking at municipalities and searching for a state.