### PR TITLE
Load context layer color scale from api

### DIFF
--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -28,29 +28,6 @@ export const CHOROPLETH_CLASSES = {
   error_no_metadata_for_layer: 'ch-no-meta-layer',
 };
 
-export const MAP_DIMENSIONS_COLOR_SCALES = {
-  'Production of soy': 'blue',
-  'Average soy yield': 'blue',
-  '% soy of total farming land': 'blue',
-  'Territorial deforestation': 'red',
-  'Maximum soy deforestation': 'red',
-  'Soy deforestation (currently only available for the Cerrado and only up until 2014)': 'red',
-  'Land based CO2 emissions': 'red',
-  'Water scarcity ': 'bluered',
-  'Loss of amphibian habitat': 'red',
-  'Area affected by fires in 2013': 'red',
-  'Permanent Protected Area (PPA) deficit': 'red',
-  'Legal Reserve (LR) deficit': 'red',
-  'Forest Code deficit': 'greenred',
-  'Number of environmental embargos (2015)': 'red',
-  '% of soy under zero deforestation commitments': 'redblue',
-  'Human development index': 'redblue',
-  'GDP per capita': 'blue',
-  '% GDP from agriculture': 'blue',
-  'Smallholder dominance ': 'green',
-  'Reported cases of forced labour (2014)': 'red',
-  'Land conflicts (2014)': 'red'
-};
 export const PROFILE_CHOROPLETH_CLASSES = ['ch-red-0', 'ch-red-1', 'ch-red-2', 'ch-red-3', 'ch-red-4'];
 
 export const NODE_SELECTION_LINKS_NUM_COLORS = 10;

--- a/scripts/reducers/helpers/getChoropleth.js
+++ b/scripts/reducers/helpers/getChoropleth.js
@@ -25,7 +25,7 @@ export default function(selectedMapDimensionsUids, nodesDictWithMeta, mapDimensi
   const isBivariate = selectedMapDimensions.length === 2;
   const isEmpty = selectedMapDimensions.length === 0;
 
-  const colors = (isBivariate) ? CHOROPLETH_CLASSES.bidimensional : CHOROPLETH_CLASSES[selectedMapDimension.color_scale || 'red'];
+  const colors = (isBivariate) ? CHOROPLETH_CLASSES.bidimensional : CHOROPLETH_CLASSES[selectedMapDimension.colorScale || 'red'];
 
   const geoNodes = _.filter(nodesDictWithMeta, node => node.geoId !== undefined && node.geoId !== null);
   const geoNodesIds = Object.keys(geoNodes);

--- a/scripts/reducers/helpers/getMapDimensions.js
+++ b/scripts/reducers/helpers/getMapDimensions.js
@@ -1,18 +1,8 @@
 import getNodeMetaUid from './getNodeMetaUid';
-import { MAP_DIMENSIONS_COLOR_SCALES } from 'constants';
 
 export default function(mapDimensions) {
   mapDimensions.forEach(dimension => {
     dimension.uid = getNodeMetaUid(dimension.type, dimension.layerAttributeId);
-  });
-
-  // hydrate mapDimensions from API with hardcoded color scales
-  // TODO ideally this should be set on the API side
-  Object.keys(MAP_DIMENSIONS_COLOR_SCALES).forEach(mapDimensionName => {
-    const mapDimension = mapDimensions.find(mapDimension => mapDimension.name === mapDimensionName);
-    if (mapDimension !== undefined) {
-      mapDimension.color_scale = MAP_DIMENSIONS_COLOR_SCALES[mapDimensionName];
-    }
   });
 
   return mapDimensions;


### PR DESCRIPTION
depends on https://github.com/Vizzuality/trase-api/pull/23

No functional change, just using API data instead of hardcoded frontend data