### PR TITLE
Remove state reset on empty flows

### DIFF
--- a/scripts/actions/tool.actions.js
+++ b/scripts/actions/tool.actions.js
@@ -251,8 +251,6 @@ export function loadLinks() {
         const jsonPayload = JSON.parse(payload);
         if (jsonPayload.data === undefined || !jsonPayload.data.length) {
           console.error('server returned empty flows/link list, with params:', params);
-          dispatch(resetState(false));
-          return;
         }
 
         dispatch({


### PR DESCRIPTION
https://basecamp.com/1756858/projects/12498794/todos/308418725

Overall, this is causing more trouble that it's probably worth. The "resetState(false)" reloads the flows again, so this is a hidden loop. It caused the 404 issue I fixed yesterday, and now is causing the issue above. 