### PR TITLE
Save and load selected map dimensions in state

### DIFF
--- a/scripts/utils/stateURL.js
+++ b/scripts/utils/stateURL.js
@@ -30,6 +30,7 @@ const URL_STATE_PROPS = [
   'expandedNodesIds',
   'areNodesExpanded',
   'selectedColumnsIds',
+  'selectedMapDimensions',
   'isMapVisible',
   'mapView',
   'expandedMapSidebarGroupsIds'


### PR DESCRIPTION
Adds selected map dimensions to state. When switching context or years, checks whether current selected dimensions are still available, otherwise use defaults. 