### PR TITLE
Fix map area highlight on changing or loading layer with preselected nodes on sankey

### DIFF
--- a/scripts/components/tool/map.component.js
+++ b/scripts/components/tool/map.component.js
@@ -321,17 +321,14 @@ export default class {
   }
 
 
-  setChoropleth({ choropleth, selectedNodesGeoIds, linkedGeoIds, choroplethLegend }) {
+  setChoropleth({ choropleth, linkedGeoIds, choroplethLegend }) {
     if (!this.currentPolygonTypeLayer) {
       return;
     }
     this.map.getPane(MAP_PANES.vectorMain).classList.toggle('-noDimensions', choroplethLegend === null);
     this._setChoropleth(choropleth);
     if (linkedGeoIds && linkedGeoIds.length) {
-      this.showLinkedGeoIds({
-        selectedNodesGeoIds,
-        linkedGeoIds
-      });
+      this.showLinkedGeoIds(linkedGeoIds);
     }
   }
 

--- a/scripts/containers/tool/map.container.js
+++ b/scripts/containers/tool/map.container.js
@@ -50,7 +50,6 @@ const mapMethodsToState = (state) => ({
     _returnedValue: (state) => {
       return {
         choropleth: state.tool.choropleth,
-        selectedNodesGeoIds: state.tool.selectedNodesGeoIds,
         linkedGeoIds: state.tool.linkedGeoIds,
         choroplethLegend: state.tool.choroplethLegend
       };


### PR DESCRIPTION
https://basecamp.com/1756858/projects/12498794/todos/315261211

Issue happens when loading a map layer (from state or by loading a new layer) when exporter is already limited per node selection