### PR TITLE
Improve logic for intervals with stars and percentual values

### DIFF
--- a/scripts/components/tool/sankey.component.js
+++ b/scripts/components/tool/sankey.component.js
@@ -293,11 +293,9 @@ export default class {
     let intervalCount = this.currentSelectedRecolorBy.intervalCount;
     if (this.currentSelectedRecolorBy.divisor) {
       intervalCount = this.currentSelectedRecolorBy.divisor * this.currentSelectedRecolorBy.intervalCount;
-    } else if (this.currentSelectedRecolorBy.legendType === 'stars') {
-      intervalCount = this.currentSelectedRecolorBy.maxValue;
     }
     if (this.currentSelectedRecolorBy.legendType !== 'percentual') {
-      return `${link.recolorBy}/${intervalCount}`;
+      return `${link.recolorBy}/${intervalCount-1}`;
     }
 
     return `${Math.round(link.recolorBy)}%`;

--- a/scripts/components/tool/sankey.component.js
+++ b/scripts/components/tool/sankey.component.js
@@ -290,9 +290,11 @@ export default class {
       return _.capitalize(link.recolorBy);
     }
 
-    let intervalCount = this.currentSelectedRecolorBy.intervalCount + 1;
+    let intervalCount = this.currentSelectedRecolorBy.intervalCount;
     if (this.currentSelectedRecolorBy.divisor) {
-      intervalCount = this.currentSelectedRecolorBy.divisor * this.currentSelectedRecolorBy.intervalCount + 1;
+      intervalCount = this.currentSelectedRecolorBy.divisor * this.currentSelectedRecolorBy.intervalCount;
+    } else if (this.currentSelectedRecolorBy.legendType === 'stars') {
+      intervalCount = this.currentSelectedRecolorBy.maxValue;
     }
     if (this.currentSelectedRecolorBy.legendType !== 'percentual') {
       return `${link.recolorBy}/${intervalCount}`;

--- a/scripts/react-components/tool/nav/recolor-by.component.js
+++ b/scripts/react-components/tool/nav/recolor-by.component.js
@@ -44,17 +44,19 @@ export default ({ tooltips, onToggle, onSelected, currentDropdown, selectedRecol
           <Tooltip position='bottom right' text={tooltips.sankey.nav.colorBy[recolorBy.name]} />
         }
       </div>
-      {recolorBy.minValue &&
-        <span class='dropdown-item-legend-unit -left'>{recolorBy.minValue}</span>
-      }
-      {recolorBy.legendType &&
-        <ul class={classNames('dropdown-item-legend', `-${recolorBy.legendType}`)}>
-          {recolorBy.legendItemsData.map(legendItem => <li class={legendItem.classNames}>{legendItem.value}</li>)}
-        </ul>
-      }
-      {recolorBy.maxValue &&
-        <span class='dropdown-item-legend-unit -right'>{recolorBy.maxValue}</span>
-      }
+      <div class='dropdown-item-legend-container'>
+        {recolorBy.minValue &&
+          <span class='dropdown-item-legend-unit -left'>{recolorBy.minValue}</span>
+        }
+        {recolorBy.legendType &&
+          <ul class={classNames('dropdown-item-legend', `-${recolorBy.legendType}`)}>
+            {recolorBy.legendItemsData.map(legendItem => <li class={legendItem.classNames}>{legendItem.value}</li>)}
+          </ul>
+        }
+        {recolorBy.maxValue &&
+          <span class='dropdown-item-legend-unit -right'>{recolorBy.maxValue}</span>
+        }
+      </div>
     </li>;
   };
 

--- a/styles/_settings.scss
+++ b/styles/_settings.scss
@@ -101,25 +101,25 @@ $recolorby-qual-thematic-caatinga: #ff66e5;
 $recolorby-qual-thematic-pampa: #72ea28;
 $recolorby-qual-thematic-pantanal: #ffb314;
 
-$recolorby-stars-red-blue-0: #e3a9a9;
-$recolorby-stars-red-blue-1: #f4bda5;
-$recolorby-stars-red-blue-2: #c2b5af;
-$recolorby-stars-red-blue-3: #92c5de;
-$recolorby-stars-red-blue-4: #4996c3;
-$recolorby-stars-red-blue-5: #000000;
+$recolorby-stars-red-blue-0: #E54935;
+$recolorby-stars-red-blue-1: #FFC389;
+$recolorby-stars-red-blue-2: #FFFECC;
+$recolorby-stars-red-blue-3: #E5F5F9;
+$recolorby-stars-red-blue-4: #79A8D0;
+$recolorby-stars-red-blue-5: #246AB6;
 
 $recolorby-qual-yes-no-yes: #a4e332;
 $recolorby-qual-yes-no-no: #e36845;
 
 
-$recolorby-linear-red-blue-7: #000000;
-$recolorby-linear-red-blue-6: #d73027;
-$recolorby-linear-red-blue-5: #fc8d59;
-$recolorby-linear-red-blue-4: #fee090;
-$recolorby-linear-red-blue-3: #ffffbf;
-$recolorby-linear-red-blue-2: #e0f3f8;
-$recolorby-linear-red-blue-1: #91bfdb;
-$recolorby-linear-red-blue-0: #4575b4;
+$recolorby-linear-red-blue-7: #E54935;
+$recolorby-linear-red-blue-6: #FFA16F;
+$recolorby-linear-red-blue-5: #FFE6A4;
+$recolorby-linear-red-blue-4: #FFFECC;
+$recolorby-linear-red-blue-3: #E5F5F9;
+$recolorby-linear-red-blue-2: #9FCAE1;
+$recolorby-linear-red-blue-1: #5488C0;
+$recolorby-linear-red-blue-0: #246AB6;
 
 $choro-red-blue-toned-down-0: #E54935;
 $choro-red-blue-toned-down-1: #FFBD78;

--- a/styles/_settings.scss
+++ b/styles/_settings.scss
@@ -106,11 +106,13 @@ $recolorby-stars-red-blue-1: #f4bda5;
 $recolorby-stars-red-blue-2: #c2b5af;
 $recolorby-stars-red-blue-3: #92c5de;
 $recolorby-stars-red-blue-4: #4996c3;
+$recolorby-stars-red-blue-5: #000000;
 
 $recolorby-qual-yes-no-yes: #a4e332;
 $recolorby-qual-yes-no-no: #e36845;
 
 
+$recolorby-linear-red-blue-7: #000000;
 $recolorby-linear-red-blue-6: #d73027;
 $recolorby-linear-red-blue-5: #fc8d59;
 $recolorby-linear-red-blue-4: #fee090;
@@ -151,9 +153,9 @@ $choro-red-green-toned-down-3: #B0DE82;
 $choro-red-green-toned-down-4: #70C67A;
 
 
-$recolorby-colors: $recolorby-qual-thematic-amazonia, $recolorby-qual-thematic-cerrado, $recolorby-qual-thematic-mata-atlantica, $recolorby-qual-thematic-caatinga, $recolorby-qual-thematic-pampa, $recolorby-qual-thematic-pantanal, $recolorby-stars-red-blue-0, $recolorby-stars-red-blue-1, $recolorby-stars-red-blue-2, $recolorby-stars-red-blue-3, $recolorby-stars-red-blue-4, $recolorby-qual-yes-no-yes, $recolorby-qual-yes-no-no, $recolorby-linear-red-blue-0, $recolorby-linear-red-blue-1, $recolorby-linear-red-blue-2, $recolorby-linear-red-blue-3, $recolorby-linear-red-blue-4, $recolorby-linear-red-blue-5, $recolorby-linear-red-blue-6, $recolorby-percentual-yellow-green-0, $recolorby-percentual-yellow-green-1, $recolorby-percentual-yellow-green-2, $recolorby-percentual-yellow-green-3, $recolorby-percentual-yellow-green-4, $recolorby-percentual-blue-green-0, $recolorby-percentual-blue-green-1, $recolorby-percentual-blue-green-2, $recolorby-percentual-blue-green-3, $recolorby-percentual-blue-green-4, $recolorby-percentual-blue-green-5, $recolorby-percentual-blue-green-6, $recolorby-percentual-blue-green-7, $recolorby-percentual-blue-green-8, $recolorby-percentual-blue-green-9, $recolorby-percentual-blue-green-10;
+$recolorby-colors: $recolorby-qual-thematic-amazonia, $recolorby-qual-thematic-cerrado, $recolorby-qual-thematic-mata-atlantica, $recolorby-qual-thematic-caatinga, $recolorby-qual-thematic-pampa, $recolorby-qual-thematic-pantanal, $recolorby-stars-red-blue-0, $recolorby-stars-red-blue-1, $recolorby-stars-red-blue-2, $recolorby-stars-red-blue-3, $recolorby-stars-red-blue-4, $recolorby-stars-red-blue-5, $recolorby-qual-yes-no-yes, $recolorby-qual-yes-no-no, $recolorby-linear-red-blue-0, $recolorby-linear-red-blue-1, $recolorby-linear-red-blue-2, $recolorby-linear-red-blue-3, $recolorby-linear-red-blue-4, $recolorby-linear-red-blue-5, $recolorby-linear-red-blue-6, $recolorby-linear-red-blue-7, $recolorby-percentual-yellow-green-0, $recolorby-percentual-yellow-green-1, $recolorby-percentual-yellow-green-2, $recolorby-percentual-yellow-green-3, $recolorby-percentual-yellow-green-4, $recolorby-percentual-blue-green-0, $recolorby-percentual-blue-green-1, $recolorby-percentual-blue-green-2, $recolorby-percentual-blue-green-3, $recolorby-percentual-blue-green-4, $recolorby-percentual-blue-green-5, $recolorby-percentual-blue-green-6, $recolorby-percentual-blue-green-7, $recolorby-percentual-blue-green-8, $recolorby-percentual-blue-green-9, $recolorby-percentual-blue-green-10;
 
-$recolorby-colors-names: '-recolorby-qual-thematic-amazonia', '-recolorby-qual-thematic-cerrado', '-recolorby-qual-thematic-mata-atlantica', '-recolorby-qual-thematic-caatinga', '-recolorby-qual-thematic-pampa', '-recolorby-qual-thematic-pantanal', '-recolorby-stars-red-blue-0', '-recolorby-stars-red-blue-1', '-recolorby-stars-red-blue-2', '-recolorby-stars-red-blue-3', '-recolorby-stars-red-blue-4', '-recolorby-qual-yes-no-yes', '-recolorby-qual-yes-no-no', '-recolorby-linear-red-blue-0', '-recolorby-linear-red-blue-1', '-recolorby-linear-red-blue-2', '-recolorby-linear-red-blue-3', '-recolorby-linear-red-blue-4', '-recolorby-linear-red-blue-5', '-recolorby-linear-red-blue-6', '-recolorby-percentual-yellow-green-0', '-recolorby-percentual-yellow-green-1', '-recolorby-percentual-yellow-green-2', '-recolorby-percentual-yellow-green-3', '-recolorby-percentual-yellow-green-4', '-recolorby-percentual-blue-green-0', '-recolorby-percentual-blue-green-1', '-recolorby-percentual-blue-green-2', '-recolorby-percentual-blue-green-3', '-recolorby-percentual-blue-green-4', '-recolorby-percentual-blue-green-5', '-recolorby-percentual-blue-green-6', '-recolorby-percentual-blue-green-7', '-recolorby-percentual-blue-green-8', '-recolorby-percentual-blue-green-9', '-recolorby-percentual-blue-green-10';
+$recolorby-colors-names: '-recolorby-qual-thematic-amazonia', '-recolorby-qual-thematic-cerrado', '-recolorby-qual-thematic-mata-atlantica', '-recolorby-qual-thematic-caatinga', '-recolorby-qual-thematic-pampa', '-recolorby-qual-thematic-pantanal', '-recolorby-stars-red-blue-0', '-recolorby-stars-red-blue-1', '-recolorby-stars-red-blue-2', '-recolorby-stars-red-blue-3', '-recolorby-stars-red-blue-4', '-recolorby-stars-red-blue-5', '-recolorby-qual-yes-no-yes', '-recolorby-qual-yes-no-no', '-recolorby-linear-red-blue-0', '-recolorby-linear-red-blue-1', '-recolorby-linear-red-blue-2', '-recolorby-linear-red-blue-3', '-recolorby-linear-red-blue-4', '-recolorby-linear-red-blue-5', '-recolorby-linear-red-blue-6', '-recolorby-linear-red-blue-7', '-recolorby-percentual-yellow-green-0', '-recolorby-percentual-yellow-green-1', '-recolorby-percentual-yellow-green-2', '-recolorby-percentual-yellow-green-3', '-recolorby-percentual-yellow-green-4', '-recolorby-percentual-blue-green-0', '-recolorby-percentual-blue-green-1', '-recolorby-percentual-blue-green-2', '-recolorby-percentual-blue-green-3', '-recolorby-percentual-blue-green-4', '-recolorby-percentual-blue-green-5', '-recolorby-percentual-blue-green-6', '-recolorby-percentual-blue-green-7', '-recolorby-percentual-blue-green-8', '-recolorby-percentual-blue-green-9', '-recolorby-percentual-blue-green-10';
 
 $recolorgroup-colors: $recolorgroup-1, $recolorgroup-2, $recolorgroup-3, $recolorgroup-4, $recolorgroup-5, $recolorgroup-6, $recolorgroup-7, $recolorgroup-8, $recolorgroup-9, $recolorgroup-10;
 
@@ -228,6 +230,7 @@ $choropleth-colors: (
   recolorby-percentual-yellow-green-2: $recolorby-percentual-yellow-green-2,
   recolorby-percentual-yellow-green-3: $recolorby-percentual-yellow-green-3,
   recolorby-percentual-yellow-green-4: $recolorby-percentual-yellow-green-4,
+  recolorby-linear-red-blue-7: $recolorby-linear-red-blue-7,
   recolorby-linear-red-blue-6: $recolorby-linear-red-blue-6,
   recolorby-linear-red-blue-5: $recolorby-linear-red-blue-5,
   recolorby-linear-red-blue-3: $recolorby-linear-red-blue-3,

--- a/styles/components/shared/dropdown.scss
+++ b/styles/components/shared/dropdown.scss
@@ -129,9 +129,14 @@
       pointer-events: none;
     }
 
+    .dropdown-item-legend-container {
+      display: flex;
+      margin-top: 10px;
+      align-items: center;
+    }
+
     .dropdown-item-legend {
       pointer-events: none;
-      margin-top: 10px;
     }
 
     .dropdown-item-legend-unit {
@@ -145,10 +150,13 @@
     }
 
     .dropdown-item-legend-unit, .dropdown-item-legend, .dropdown-item-legend > li {
-      display: inline-block;
       color: $charcoal-grey;
       font-family: $font-family-1;
       font-size: $font-size-small;
+    }
+
+    .dropdown-item-legend, .dropdown-item-legend > li {
+      display: inline-block;
     }
 
     .dropdown-item-legend.-qual > li {


### PR DESCRIPTION
ToDo:
- When using min and max values with starts, the numbers on the "recolor by" dropdown menu need to be alligned 
- Forest 500 and water scarcity need another color

![image](https://user-images.githubusercontent.com/973964/28728861-8f3c8f78-73ca-11e7-86b5-788a2fff2e04.png)
