### PR TITLE
reset linked polygons layer when switching context

### DIFF
--- a/scripts/components/tool/map.component.js
+++ b/scripts/components/tool/map.component.js
@@ -111,9 +111,6 @@ export default class {
 
 
   showLinkedGeoIds(linkedGeoIds) {
-    if (!this.currentPolygonTypeLayer) {
-      return;
-    }
     // remove choropleth from main layer
     this.map.getPane(MAP_PANES.vectorMain).classList.toggle('-linkedActivated', linkedGeoIds.length);
 
@@ -126,6 +123,9 @@ export default class {
       return;
     }
 
+    if (!this.currentPolygonTypeLayer) {
+      return;
+    }
     const linkedFeaturesClassNames = {};
 
     const linkedFeatures = linkedGeoIds.map(geoId => {


### PR DESCRIPTION
Just lets the map component clean up linked layer when receiving an empty selection.