### PR TITLE
fixed map polygons hover and click

### DIFF
--- a/scripts/components/tool/map.component.js
+++ b/scripts/components/tool/map.component.js
@@ -277,15 +277,13 @@ export default class {
       const that = this;
       layer.on({
         mouseover: function(event) {
-          if (event.target.disabled) return;
           that.callbacks.onPolygonHighlighted(this.feature.properties.geoid, { pageX: event.originalEvent.pageX, pageY: event.originalEvent.pageY });
         },
         mouseout: function() {
-          if (event.target.disabled) return;
           that.callbacks.onPolygonHighlighted();
         },
         click: function() {
-          if (event.target.disabled) return;
+          if (event.target.disabled || (event.target.classList && event.target.classList.contains('-disabled'))) return;
           that.callbacks.onPolygonClicked(this.feature.properties.geoid);
         }
       });

--- a/scripts/containers/tool/map.container.js
+++ b/scripts/containers/tool/map.container.js
@@ -67,6 +67,7 @@ const mapMethodsToState = (state) => ({
       return {
         linkedGeoIds: state.tool.linkedGeoIds,
         defaultMapView: state.tool.selectedContext.map,
+        // get back to context default map view if no nodes are selected
         forceDefaultMapView: !state.tool.selectedNodesIds.length
       };
     }


### PR DESCRIPTION
Fixes 2 issues with disabled polygons:
- puts back tooltip on hover
- prevents clicking on them (avoiding tool lock)